### PR TITLE
feat: Ajouter la fonctionnalité de sélection d'utilisateurs pour l'ajout d'heures

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -94,6 +94,7 @@ export default function AdminPage() {
   const [confirmResetPassword, setConfirmResetPassword] = useState(false);
   const [users, setUsers] = useState<User[]>([]);
   const [confirmPasswordChange, setConfirmPasswordChange] = useState(false);
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
   const { refetchSettings } = useSettings();
 
   useEffect(() => {
@@ -223,6 +224,7 @@ export default function AdminPage() {
         date: dateString,
         duration: totalMinutes,
         reason,
+        userIds: selectedUserIds.length > 0 ? selectedUserIds : undefined,
       }),
     });
     if (res.ok) {
@@ -230,6 +232,7 @@ export default function AdminPage() {
       setHoursInput('');
       setMinutesInput('');
       setReason('');
+      setSelectedUserIds([]);
       fetchHours();
       toast.success('Heure ajoutée avec succès');
     } else {
@@ -385,6 +388,38 @@ export default function AdminPage() {
         </CardHeader>
         <CardContent>
           <form onSubmit={handleAddHour} className="space-y-4">
+            <div>
+              <Label className="mb-2 block">
+                Utilisateurs (laisser vide pour vous-même)
+              </Label>
+              <div className="h-40 overflow-y-auto border rounded p-2 space-y-2 bg-white dark:bg-stone-900">
+                {users.map((user) => (
+                  <div key={user.id} className="flex items-center space-x-2">
+                    <input
+                      type="checkbox"
+                      id={`user-${user.id}`}
+                      checked={selectedUserIds.includes(user.id)}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setSelectedUserIds([...selectedUserIds, user.id]);
+                        } else {
+                          setSelectedUserIds(
+                            selectedUserIds.filter((id) => id !== user.id),
+                          );
+                        }
+                      }}
+                      className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                    />
+                    <Label
+                      htmlFor={`user-${user.id}`}
+                      className="cursor-pointer font-normal"
+                    >
+                      {user.firstName} {user.lastName} ({user.email})
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            </div>
             <div>
               <Label htmlFor="date">Date</Label>
               <DatePicker date={date} setDate={setDate} />

--- a/app/api/hours/route.ts
+++ b/app/api/hours/route.ts
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 });
   }
 
-  const { date, duration, reason } = await request.json();
+  const { date, duration, reason, userIds } = await request.json();
 
   if (!date || !duration || !reason) {
     return NextResponse.json(
@@ -74,17 +74,39 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const userId = session.user.id;
+  let targetUserIds = [session.user.id];
+  let status = 'PENDING';
+  let validatedById = undefined;
 
-  const hour = await prisma.hour.create({
-    data: {
-      id: uuidv4(),
-      date: new Date(date),
-      duration,
-      reason,
-      userId,
-    },
-  });
+  if (userIds && Array.isArray(userIds) && userIds.length > 0) {
+    if (session.user.role === 'ADMIN' || session.user.role === 'SUPER_ADMIN') {
+      targetUserIds = userIds;
+      status = 'VALIDATED';
+      validatedById = session.user.id;
+    } else {
+      return NextResponse.json(
+        { error: "Non autorisé à ajouter des heures pour d'autres utilisateurs" },
+        { status: 403 },
+      );
+    }
+  }
 
-  return NextResponse.json(hour);
+  const createdHours = [];
+
+  for (const uid of targetUserIds) {
+    const hour = await prisma.hour.create({
+      data: {
+        id: uuidv4(),
+        date: new Date(date),
+        duration,
+        reason,
+        userId: uid,
+        status: status as any,
+        validatedById,
+      },
+    });
+    createdHours.push(hour);
+  }
+
+  return NextResponse.json(createdHours);
 }


### PR DESCRIPTION
This pull request adds the ability for admins to add hours on behalf of multiple users at once from the admin interface. The changes include updates to both the frontend (`AdminPage`) and backend (`/api/hours` route) to support selecting users, validating permissions, and handling the creation of hours for multiple users.

**Frontend: User selection and form handling**

- Added a multi-user selection UI to the add hours form, allowing admins to select one or more users to attribute hours to; if left empty, hours are attributed to the current user. [[1]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R97) [[2]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R391-R422)
- Updated form submission logic to include selected user IDs in the payload and reset the selection after successful submission.

**Backend: API and permission logic**

- Updated the `/api/hours` POST endpoint to accept an optional `userIds` array and to create hour entries for each selected user. [[1]](diffhunk://#diff-53f5b1f527e0d09d7aee7f875a64881f5793a728b70fb4f6cb726c8c893ff048L68-R68) [[2]](diffhunk://#diff-53f5b1f527e0d09d7aee7f875a64881f5793a728b70fb4f6cb726c8c893ff048L77-R111)
- Implemented role-based permission checks: only admins and super admins can add hours for other users, and such entries are automatically validated. Non-admins can only add hours for themselves.

Closes #19 