### PR TITLE
fix: Corriger les chemins d'importation pour les composants et ajuster la configuration TypeScript

### DIFF
--- a/app/admin/import-users/page.tsx
+++ b/app/admin/import-users/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Button } from '../../../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../../../components/ui/card';
+import { Input } from '../../../components/ui/input';
+import { Label } from '../../../components/ui/label';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../../../components/ui/dialog';
 import { toast } from 'sonner';
 
 interface ParsedUser {

--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -4,12 +4,12 @@ import * as React from "react"
 import { Moon, Sun, Laptop } from "lucide-react"
 import { useTheme } from "next-themes"
 
-import { Button } from "@/components/ui/button"
+import { Button } from "./ui/button"
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover"
+} from "./ui/popover"
 
 export function ModeToggle() {
   const { setTheme, theme } = useTheme()

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { CheckIcon } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 function Checkbox({
   className,

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 function Select({
   ...props

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -28,7 +34,10 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next\\dev/types/**/*.ts",
-    ".next\\dev/types/**/*.ts"
+    ".next\\dev/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This pull request primarily updates import paths throughout the codebase, replacing alias-based imports (using `@/`) with relative paths. This change ensures that component and utility imports are resolved correctly, likely to improve compatibility with certain tooling or deployment environments.

**Import path updates:**

* Changed all imports of UI components in `app/admin/import-users/page.tsx` from alias-based (`@/components/ui/...`) to relative paths (`../../../components/ui/...`).
* Updated imports of `Button` and `Popover` components in `components/mode-toggle.tsx` from alias-based to relative paths (`./ui/...`).
* Changed import of the `cn` utility in `components/ui/checkbox.tsx` from alias-based to relative path (`../../lib/utils`).
* Changed import of the `cn` utility in `components/ui/select.tsx` from alias-based to relative path (`../../lib/utils`).